### PR TITLE
Dispatch a repository_dispatch event to glasnost-distro-packer

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -221,11 +221,23 @@ jobs:
         # per-artifact *.meta.json -- publishing both is pure clutter.
         run: rm -f release-assets/*.meta.json
 
-      # TODO(coordinator-repo): once a version-pinning coordinator repo
-      # exists, fire a repository_dispatch event here with
-      # release-assets/manifest.json as the payload so it can open a
-      # human-reviewed version-bump PR. No target repo exists yet, so this
-      # is intentionally left unwired rather than pointed at nothing.
+      # Requires repo secret GLASNOST_DISPATCH_TOKEN (not yet created) --
+      # GITHUB_TOKEN can't dispatch cross-repo.
+      - name: Notify glasnost-distro-packer of this release
+        env:
+          GH_TOKEN: ${{ secrets.GLASNOST_DISPATCH_TOKEN }}
+        run: |
+          set -eu
+          ref=$(jq -r '.[0].version' release-assets/manifest.json)
+          payload=$(jq -n \
+            --arg repo "printarescu-labs/vnd_microchip_at91bootstrap3" \
+            --arg ref "$ref" \
+            '{event_type: "component-released", client_payload: {repo: $repo, ref: $ref}}')
+          echo "$payload" | gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/printarescu-labs/glasnost-distro-packer/dispatches \
+            --input -
 
       - name: Create release
         uses: softprops/action-gh-release@v3.0.2


### PR DESCRIPTION
The coordinator repo (printarescu-labs/glasnost-distro-packer) that the existing TODO in the release job anticipated now exists. Wire it up: fire a component-released repository_dispatch via the official `gh` CLI (no third-party action), carrying repo + ref in client_payload.

The ref is read back out of release-assets/manifest.json's version field (already computed per-build via `git describe`) rather than github.ref_name, since that field is guaranteed to match what's actually attached to this release regardless of how github.ref_name propagates through the workflow_call chain.

The step is added under the release job, which already gates on `if: inputs.create_release && !cancelled()` at the job level, so no step-level condition is needed.
